### PR TITLE
[백엔드] 모집글 생성하는 API 개발

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: 9-in Team 테스트 자동화
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 프로젝트 체크아웃합니다.
+        uses: actions/checkout@v2
+
+      - name: JDK 21을 설치합니다.
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+
+      - name: TimeZone을 Asia/Seoul로 설정합니다
+        uses: zcong1993/setup-timezone@master
+        with:
+          timezone: Asia/Seoul
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Gradle 명령 실행을 위한 권한을 부여합니다
+        run: chmod +x gradlew
+
+      - name: Gradle build를 수행합니다
+        run: ./gradlew clean build
+
+      - name: 테스트 결과를 PR에 코멘트로 등록합니다
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' apply(false)
     id 'io.spring.dependency-management'
     id 'com.diffplug.spotless'
+    id 'jacoco'
 }
 
 allprojects {
@@ -39,7 +40,6 @@ subprojects {
         useJUnitPlatform()
     }
 
-    // java format
     subprojects {
         spotless {
             java {
@@ -50,6 +50,13 @@ subprojects {
                 indentWithSpaces(4)
                 endWithNewline()
             }
+        }
+    }
+
+    jacocoTestReport {
+        reports {
+            html.enabled true
+            xml.enabled true
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -52,11 +52,4 @@ subprojects {
             }
         }
     }
-
-    jacocoTestReport {
-        reports {
-            html.enabled true
-            xml.enabled true
-        }
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'org.springframework.boot' apply(false)
+    id 'org.asciidoctor.jvm.convert' apply(false)
     id 'io.spring.dependency-management'
     id 'com.diffplug.spotless'
     id 'jacoco'
@@ -19,6 +20,7 @@ allprojects {
 subprojects {
     apply plugin: 'java'
     apply plugin: 'org.springframework.boot'
+    apply plugin: 'org.asciidoctor.jvm.convert'
     apply plugin: 'io.spring.dependency-management'
 
     bootJar.enabled = false
@@ -38,18 +40,5 @@ subprojects {
 
     tasks.named('test') {
         useJUnitPlatform()
-    }
-
-    subprojects {
-        spotless {
-            java {
-                googleJavaFormat()
-
-                removeUnusedImports()
-                trimTrailingWhitespace()
-                indentWithSpaces(4)
-                endWithNewline()
-            }
-        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,8 @@ javaVersion=21
 springBootVersion=3.2.0
 springDependencyManagementVersion=1.1.4
 spotlessVersion=6.21.0
+asciidoctorConvertVersion=3.3.2
+
+### library version ###
+fixtureMockeyVersion=1.0.5
+guavaVersion=31.1-jre

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ pluginManagement {
         id 'org.springframework.boot' version "${springBootVersion}"
         id 'io.spring.dependency-management' version "${springDependencyManagementVersion}"
         id 'com.diffplug.spotless' version "${spotlessVersion}"
+        id 'org.asciidoctor.jvm.convert' version "${asciidoctorConvertVersion}"
     }
 }
 
@@ -10,4 +11,3 @@ rootProject.name = 'guinTeam'
 include 'chatting-service'
 include 'account-service'
 include 'team-service'
-

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,5 @@ pluginManagement {
 rootProject.name = 'guinTeam'
 include 'chatting-service'
 include 'account-service'
+include 'team-service'
 

--- a/team-service/build.gradle
+++ b/team-service/build.gradle
@@ -1,0 +1,11 @@
+bootJar.enabled = true
+jar.enabled = false
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    runtimeOnly 'com.h2database:h2'
+}

--- a/team-service/build.gradle
+++ b/team-service/build.gradle
@@ -7,5 +7,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'jakarta.servlet:jakarta.servlet-api'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation "com.google.guava:guava:${guavaVersion}"
+
     runtimeOnly 'com.h2database:h2'
+
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+    testImplementation 'io.rest-assured:spring-mock-mvc'
+    testImplementation "com.navercorp.fixturemonkey:fixture-monkey-starter:${fixtureMockeyVersion}"
 }

--- a/team-service/src/docs/team.adoc
+++ b/team-service/src/docs/team.adoc
@@ -1,0 +1,12 @@
+= 9-in Team REST Docs (글의 제목)
+guinTeam(부제)
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs // 문서에 표기되는 코드들의 하이라이팅을 highlightjs를 사용
+:toc: left // toc (Table Of Contents)를 문서의 좌측에 두기
+:toclevels: 2
+:sectlinks:
+
+[[Team-API]]
+== 모집글 생성 API
+operation::createProject[snippets='http-request,request-fields,http-response,response-fields']

--- a/team-service/src/main/java/com/guin/team/TeamServiceApplication.java
+++ b/team-service/src/main/java/com/guin/team/TeamServiceApplication.java
@@ -1,0 +1,11 @@
+package com.guin.team;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TeamServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TeamServiceApplication.class, args);
+    }
+}

--- a/team-service/src/main/java/com/guin/team/adapter/in/web/TeamController.java
+++ b/team-service/src/main/java/com/guin/team/adapter/in/web/TeamController.java
@@ -1,0 +1,42 @@
+package com.guin.team.adapter.in.web;
+
+import com.guin.team.adapter.in.web.dto.request.TeamCreateRequest;
+import com.guin.team.adapter.in.web.dto.response.TeamCreateResponse;
+import com.guin.team.domain.vo.Team;
+import com.guin.team.port.in.TeamUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.Collections;
+
+@RestController
+@RequestMapping("/team")
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamUseCase teamUseCase;
+
+    @PostMapping
+    public ResponseEntity<TeamCreateResponse> createTeam(@Valid @RequestBody TeamCreateRequest request) {
+        final Team team = teamUseCase.save(request);
+
+        return ResponseEntity.created(URI.create("/team/%d".formatted(team.id())))
+                .body(new TeamCreateResponse(
+                        team.id(),
+                        team.openChatUrl(),
+                        team.content(),
+                        team.subject(),
+                        team.subjectType(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList()
+                ));
+    }
+
+}

--- a/team-service/src/main/java/com/guin/team/adapter/in/web/dto/request/TeamCreateRequest.java
+++ b/team-service/src/main/java/com/guin/team/adapter/in/web/dto/request/TeamCreateRequest.java
@@ -3,6 +3,7 @@ package com.guin.team.adapter.in.web.dto.request;
 import com.guin.team.domain.constant.SubjectType;
 import com.guin.team.domain.constant.TemplateType;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
@@ -13,7 +14,7 @@ public record TeamCreateRequest(
         String content,
         @NotBlank(message = "오픈채팅은 빈 값을 넣을 수 없습니다.")
         String openChatUrl,
-        @NotBlank(message = "주제타입은 빈 값을 넣을 수 없습니다.")
+        @NotNull(message = "주제타입은 빈 값을 넣을 수 없습니다.")
         SubjectType subjectType,
         List<TeamCreateTemplateRequest> teamTemplates,
         List<String> types,

--- a/team-service/src/main/java/com/guin/team/adapter/in/web/dto/request/TeamCreateRequest.java
+++ b/team-service/src/main/java/com/guin/team/adapter/in/web/dto/request/TeamCreateRequest.java
@@ -1,0 +1,36 @@
+package com.guin.team.adapter.in.web.dto.request;
+
+import com.guin.team.domain.constant.SubjectType;
+import com.guin.team.domain.constant.TemplateType;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record TeamCreateRequest(
+        @NotBlank(message = "제목은 빈값을 넣을 수 없습니다.")
+        String subject,
+        @NotBlank(message = "내용은 빈 값을 넣을 수 없습니다.")
+        String content,
+        @NotBlank(message = "오픈채팅은 빈 값을 넣을 수 없습니다.")
+        String openChatUrl,
+        @NotBlank(message = "주제타입은 빈 값을 넣을 수 없습니다.")
+        SubjectType subjectType,
+        List<TeamCreateTemplateRequest> teamTemplates,
+        List<String> types,
+        List<TeamCreateRoleRequest> roles
+) {
+
+    public record TeamCreateTemplateRequest(
+            TemplateType type,
+            String question,
+            String option
+    ) {
+    }
+
+    public record TeamCreateRoleRequest(
+            String name,
+            int requiredCount
+    ) {
+    }
+
+}

--- a/team-service/src/main/java/com/guin/team/adapter/in/web/dto/request/TeamCreateRequest.java
+++ b/team-service/src/main/java/com/guin/team/adapter/in/web/dto/request/TeamCreateRequest.java
@@ -12,7 +12,6 @@ public record TeamCreateRequest(
         String subject,
         @NotBlank(message = "내용은 빈 값을 넣을 수 없습니다.")
         String content,
-        @NotBlank(message = "오픈채팅은 빈 값을 넣을 수 없습니다.")
         String openChatUrl,
         @NotNull(message = "주제타입은 빈 값을 넣을 수 없습니다.")
         SubjectType subjectType,

--- a/team-service/src/main/java/com/guin/team/adapter/in/web/dto/response/TeamCreateResponse.java
+++ b/team-service/src/main/java/com/guin/team/adapter/in/web/dto/response/TeamCreateResponse.java
@@ -1,0 +1,31 @@
+package com.guin.team.adapter.in.web.dto.response;
+
+import com.guin.team.domain.constant.SubjectType;
+import com.guin.team.domain.constant.TemplateType;
+
+import java.util.List;
+
+public record TeamCreateResponse(
+        Long teamId,
+        String openChatUrl,
+        String content,
+        String subject,
+        SubjectType subjectType,
+        List<TeamTemplateDetail> teamTemplates,
+        List<String> types,
+        List<TeamRoleDetail> teamRoleDetail
+) {
+
+    public record TeamTemplateDetail(
+        TemplateType type,
+        String question,
+        String options
+    ) { }
+
+    public record TeamRoleDetail(
+            String name,
+            int requiredCount,
+            int hiredCount
+    ) { }
+
+}

--- a/team-service/src/main/java/com/guin/team/adapter/out/persistence/TeamPersistenceAdapter.java
+++ b/team-service/src/main/java/com/guin/team/adapter/out/persistence/TeamPersistenceAdapter.java
@@ -1,0 +1,34 @@
+package com.guin.team.adapter.out.persistence;
+
+import com.guin.team.adapter.out.persistence.entity.TeamEntity;
+import com.guin.team.adapter.out.persistence.mapper.TeamMapper;
+import com.guin.team.adapter.out.persistence.repository.TeamRepository;
+import com.guin.team.application.dto.TeamCommand;
+import com.guin.team.domain.vo.Team;
+import com.guin.team.port.out.TeamPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class TeamPersistenceAdapter implements TeamPort {
+
+    private final TeamRepository teamRepository;
+    private final TeamMapper teamMapper;
+
+    @Override
+    @Transactional
+    public Team save(final TeamCommand teamCommand) {
+        // TODO: 회원 서버와 연동이되면 그때 저장 가능.
+        return teamMapper.toMapper(
+                teamRepository.save(new TeamEntity(
+                        1L,
+                        teamCommand.subject(),
+                        teamCommand.content(),
+                        teamCommand.subjectType(),
+                        teamCommand.openChatUrl()
+                ))
+        );
+    }
+}

--- a/team-service/src/main/java/com/guin/team/adapter/out/persistence/TeamPersistenceAdapter.java
+++ b/team-service/src/main/java/com/guin/team/adapter/out/persistence/TeamPersistenceAdapter.java
@@ -8,7 +8,6 @@ import com.guin.team.domain.vo.Team;
 import com.guin.team.port.out.TeamPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -18,7 +17,6 @@ public class TeamPersistenceAdapter implements TeamPort {
     private final TeamMapper teamMapper;
 
     @Override
-    @Transactional
     public Team save(final TeamCommand teamCommand) {
         // TODO: 회원 서버와 연동이되면 그때 저장 가능.
         return teamMapper.toMapper(

--- a/team-service/src/main/java/com/guin/team/adapter/out/persistence/entity/TeamEntity.java
+++ b/team-service/src/main/java/com/guin/team/adapter/out/persistence/entity/TeamEntity.java
@@ -29,7 +29,7 @@ public class TeamEntity {
     @Enumerated(EnumType.STRING)
     private SubjectType subjectType;
 
-    @Column(name = "open_chat_url", nullable = false, length = 500)
+    @Column(name = "open_chat_url", length = 500)
     private String openChatUrl;
 
     public TeamEntity(final Long leaderId,

--- a/team-service/src/main/java/com/guin/team/adapter/out/persistence/entity/TeamEntity.java
+++ b/team-service/src/main/java/com/guin/team/adapter/out/persistence/entity/TeamEntity.java
@@ -1,0 +1,46 @@
+package com.guin.team.adapter.out.persistence.entity;
+
+import com.guin.team.domain.constant.SubjectType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "team")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamEntity {
+
+    @Id
+    @GeneratedValue( strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "leader_id", nullable = false)
+    private Long leaderId;
+
+    @Column(name = "subject", nullable = false)
+    private String subject;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "Subject_type", nullable = false, length = 10)
+    @Enumerated(EnumType.STRING)
+    private SubjectType subjectType;
+
+    @Column(name = "open_chat_url", nullable = false, length = 500)
+    private String openChatUrl;
+
+    public TeamEntity(final Long leaderId,
+                      final String subject,
+                      final String content,
+                      final SubjectType subjectType,
+                      final String openChatUrl) {
+        this.leaderId = leaderId;
+        this.subject = subject;
+        this.content = content;
+        this.subjectType = subjectType;
+        this.openChatUrl = openChatUrl;
+    }
+}

--- a/team-service/src/main/java/com/guin/team/adapter/out/persistence/mapper/TeamMapper.java
+++ b/team-service/src/main/java/com/guin/team/adapter/out/persistence/mapper/TeamMapper.java
@@ -1,0 +1,21 @@
+package com.guin.team.adapter.out.persistence.mapper;
+
+import com.guin.team.adapter.out.persistence.entity.TeamEntity;
+import com.guin.team.domain.vo.Team;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TeamMapper {
+
+    public Team toMapper(final TeamEntity teamEntity) {
+        return new Team(
+                teamEntity.getId(),
+                teamEntity.getLeaderId(),
+                teamEntity.getSubject(),
+                teamEntity.getContent(),
+                teamEntity.getSubjectType(),
+                teamEntity.getOpenChatUrl()
+        );
+    }
+
+}

--- a/team-service/src/main/java/com/guin/team/adapter/out/persistence/repository/JpaTeamRepository.java
+++ b/team-service/src/main/java/com/guin/team/adapter/out/persistence/repository/JpaTeamRepository.java
@@ -1,0 +1,7 @@
+package com.guin.team.adapter.out.persistence.repository;
+
+import com.guin.team.adapter.out.persistence.entity.TeamEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaTeamRepository extends TeamRepository, JpaRepository<TeamEntity, Long> {
+}

--- a/team-service/src/main/java/com/guin/team/adapter/out/persistence/repository/TeamRepository.java
+++ b/team-service/src/main/java/com/guin/team/adapter/out/persistence/repository/TeamRepository.java
@@ -1,7 +1,16 @@
 package com.guin.team.adapter.out.persistence.repository;
 
 import com.guin.team.adapter.out.persistence.entity.TeamEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TeamRepository extends JpaRepository<TeamEntity, Long> {
+import java.util.List;
+import java.util.Optional;
+
+public interface TeamRepository {
+
+    TeamEntity save(final TeamEntity teamEntity);
+
+    Optional<TeamEntity> findById(final Long id);
+
+    List<TeamEntity> findAll();
+
 }

--- a/team-service/src/main/java/com/guin/team/adapter/out/persistence/repository/TeamRepository.java
+++ b/team-service/src/main/java/com/guin/team/adapter/out/persistence/repository/TeamRepository.java
@@ -1,0 +1,7 @@
+package com.guin.team.adapter.out.persistence.repository;
+
+import com.guin.team.adapter.out.persistence.entity.TeamEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<TeamEntity, Long> {
+}

--- a/team-service/src/main/java/com/guin/team/application/TeamService.java
+++ b/team-service/src/main/java/com/guin/team/application/TeamService.java
@@ -1,0 +1,30 @@
+package com.guin.team.application;
+
+import com.guin.team.adapter.in.web.dto.request.TeamCreateRequest;
+import com.guin.team.application.dto.TeamCommand;
+import com.guin.team.domain.vo.Team;
+import com.guin.team.port.in.TeamUseCase;
+import com.guin.team.port.out.TeamPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService implements TeamUseCase {
+
+    private final TeamPort teamPort;
+
+    @Override
+    @Transactional
+    public Team save(final TeamCreateRequest request) {
+        return teamPort.save(
+                new TeamCommand(
+                        request.subject(),
+                        request.content(),
+                        request.subjectType(),
+                        request.openChatUrl()
+                )
+        );
+    }
+}

--- a/team-service/src/main/java/com/guin/team/application/dto/TeamCommand.java
+++ b/team-service/src/main/java/com/guin/team/application/dto/TeamCommand.java
@@ -1,0 +1,10 @@
+package com.guin.team.application.dto;
+
+import com.guin.team.domain.constant.SubjectType;
+
+public record TeamCommand(
+        String subject,
+        String content,
+        SubjectType subjectType,
+        String openChatUrl
+) { }

--- a/team-service/src/main/java/com/guin/team/domain/constant/SubjectType.java
+++ b/team-service/src/main/java/com/guin/team/domain/constant/SubjectType.java
@@ -1,6 +1,15 @@
 package com.guin.team.domain.constant;
 
+import java.util.Arrays;
+
 public enum SubjectType {
     PROJECT,
-    STUDY
+    STUDY;
+
+    public static SubjectType from(final String type) {
+        return Arrays.stream(values())
+                .filter(value -> value.name().equals(type))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
 }

--- a/team-service/src/main/java/com/guin/team/domain/constant/SubjectType.java
+++ b/team-service/src/main/java/com/guin/team/domain/constant/SubjectType.java
@@ -1,0 +1,6 @@
+package com.guin.team.domain.constant;
+
+public enum SubjectType {
+    PROJECT,
+    STUDY
+}

--- a/team-service/src/main/java/com/guin/team/domain/constant/TemplateType.java
+++ b/team-service/src/main/java/com/guin/team/domain/constant/TemplateType.java
@@ -1,0 +1,8 @@
+package com.guin.team.domain.constant;
+
+public enum TemplateType {
+    FILE,
+    IMAGE,
+    TEXT,
+    CHECKBOX
+}

--- a/team-service/src/main/java/com/guin/team/domain/vo/Team.java
+++ b/team-service/src/main/java/com/guin/team/domain/vo/Team.java
@@ -1,0 +1,12 @@
+package com.guin.team.domain.vo;
+
+import com.guin.team.domain.constant.SubjectType;
+
+public record Team(
+    Long id,
+    Long leaderId,
+    String subject,
+    String content,
+    SubjectType subjectType,
+    String openChatUrl
+) { }

--- a/team-service/src/main/java/com/guin/team/port/in/TeamUseCase.java
+++ b/team-service/src/main/java/com/guin/team/port/in/TeamUseCase.java
@@ -1,0 +1,10 @@
+package com.guin.team.port.in;
+
+import com.guin.team.adapter.in.web.dto.request.TeamCreateRequest;
+import com.guin.team.domain.vo.Team;
+
+public interface TeamUseCase {
+
+    Team save(TeamCreateRequest request);
+
+}

--- a/team-service/src/main/java/com/guin/team/port/out/TeamPort.java
+++ b/team-service/src/main/java/com/guin/team/port/out/TeamPort.java
@@ -1,0 +1,10 @@
+package com.guin.team.port.out;
+
+import com.guin.team.application.dto.TeamCommand;
+import com.guin.team.domain.vo.Team;
+
+public interface TeamPort {
+
+    Team save(TeamCommand teamCommand);
+
+}

--- a/team-service/src/main/resources/application-local.yml
+++ b/team-service/src/main/resources/application-local.yml
@@ -1,0 +1,27 @@
+server:
+  port: 8089
+
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:core;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true

--- a/team-service/src/main/resources/application.yml
+++ b/team-service/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: team-service
+
+  profiles:
+    default: local

--- a/team-service/src/test/java/com/guin/team/acceptance/AcceptanceTest.java
+++ b/team-service/src/test/java/com/guin/team/acceptance/AcceptanceTest.java
@@ -1,0 +1,25 @@
+package com.guin.team.acceptance;
+
+import com.guin.team.util.DataCleanUp;
+import io.restassured.RestAssured;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.TestConstructor;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+public abstract class AcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private DataCleanUp dataCleanUp;
+
+    public void setUp() {
+        RestAssured.port = port;
+        dataCleanUp.execute();
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/acceptance/TeamAcceptance.java
+++ b/team-service/src/test/java/com/guin/team/acceptance/TeamAcceptance.java
@@ -1,0 +1,71 @@
+package com.guin.team.acceptance;
+
+import com.guin.team.acceptance.step.TeamControllerStep;
+import com.guin.team.adapter.in.web.dto.request.TeamCreateRequest;
+import com.guin.team.adapter.in.web.dto.response.TeamCreateResponse;
+import com.guin.team.adapter.out.persistence.entity.TeamEntity;
+import com.guin.team.adapter.out.persistence.repository.TeamRepository;
+import com.guin.team.domain.constant.SubjectType;
+import com.guin.team.fixture.dto.TeamCreateRequestFixture;
+import com.guin.team.fixture.dto.TeamCreateResponseFixture;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TeamAcceptance extends AcceptanceTest {
+
+    private final TeamRepository teamRepository;
+
+    private TeamCreateRequest request;
+
+    public TeamAcceptance(final TeamRepository teamRepository) {
+        this.teamRepository = teamRepository;
+    }
+
+    @BeforeEach
+    void setup() {
+        super.setUp();
+        this.request = TeamCreateRequestFixture.create("제목");
+    }
+
+    @DisplayName("모집글을 생성한다.")
+    @Test
+    void createProject() {
+        JsonPath response = TeamControllerStep.create(request).jsonPath();
+
+        TeamEntity teamEntity = teamRepository.findAll().get(0);
+
+        TeamCreateResponse actual = TeamCreateResponseFixture.create(
+                teamEntity.getId(),
+                teamEntity.getOpenChatUrl(),
+                teamEntity.getContent(),
+                teamEntity.getSubject(),
+                teamEntity.getSubjectType()
+        );
+
+        assertThat(actual).isEqualTo(TeamCreateResponseFixture.create(
+                response.getLong("teamId"),
+                response.getString("openChatUrl"),
+                response.getString("content"),
+                response.getString("subject"),
+                SubjectType.from(response.getString("subjectType"))
+        ));
+    }
+
+    @DisplayName("파라미터에 필수값이 누락될 경우 에러를 반환한다.")
+    @Test
+    void invalidParameter() {
+        TeamCreateRequest errorRequest = new TeamCreateRequest(null, null, null, null, null, null, null);
+
+        ExtractableResponse<Response> response = TeamControllerStep.create(errorRequest);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/acceptance/step/TeamControllerStep.java
+++ b/team-service/src/test/java/com/guin/team/acceptance/step/TeamControllerStep.java
@@ -1,0 +1,21 @@
+package com.guin.team.acceptance.step;
+
+import com.guin.team.adapter.in.web.dto.request.TeamCreateRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+public class TeamControllerStep {
+
+    public static ExtractableResponse<Response> create(TeamCreateRequest request) {
+        return RestAssured
+                .given().log().all()
+                .body(request)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/team")
+                .then().log().all()
+                .extract();
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/documentation/DocumentPreprocessor.java
+++ b/team-service/src/test/java/com/guin/team/documentation/DocumentPreprocessor.java
@@ -1,0 +1,25 @@
+package com.guin.team.documentation;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+public class DocumentPreprocessor {
+
+    private static final String HTTP = "http";
+    private static final String LOCALHOST = "localhost";
+
+    public static OperationRequestPreprocessor requestPreprocessor() {
+        return Preprocessors.preprocessRequest(
+                Preprocessors.modifyUris()
+                        .scheme(HTTP)
+                        .host(LOCALHOST)
+                        .removePort(),
+                Preprocessors.prettyPrint());
+    }
+
+    public static OperationResponsePreprocessor responsePreprocessor() {
+        return Preprocessors.preprocessResponse(Preprocessors.prettyPrint());
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/documentation/Documentation.java
+++ b/team-service/src/test/java/com/guin/team/documentation/Documentation.java
@@ -1,0 +1,51 @@
+package com.guin.team.documentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class Documentation {
+
+    protected MockMvcRequestSpecification mockMvc;
+    private RestDocumentationContextProvider restDocumentation;
+
+    @BeforeEach
+    public void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.restDocumentation = restDocumentation;
+    }
+
+    protected MockMvcRequestSpecification given() {
+        return this.mockMvc;
+    }
+
+    protected MockMvcRequestSpecification mockController(Object controller) {
+        MockMvc mockMvc = createMockMvc(controller);
+        return RestAssuredMockMvc.given().mockMvc(mockMvc);
+    }
+
+    private MockMvc createMockMvc(Object controller) {
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter(objectMapper());
+
+        return MockMvcBuilders.standaloneSetup(controller)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentation))
+                .setMessageConverters(converter)
+                .build();
+    }
+
+    private ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules()
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS);
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/documentation/TeamDocumentationTest.java
+++ b/team-service/src/test/java/com/guin/team/documentation/TeamDocumentationTest.java
@@ -1,0 +1,54 @@
+package com.guin.team.documentation;
+
+import com.guin.team.fixture.domain.TeamFixture;
+import com.guin.team.fixture.dto.TeamCreateRequestFixture;
+import com.guin.team.adapter.in.web.TeamController;
+import com.guin.team.adapter.in.web.dto.request.TeamCreateRequest;
+import com.guin.team.application.TeamService;
+import com.guin.team.port.in.TeamUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static com.guin.team.documentation.step.TeamDocumentStep.resultHandler;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TeamDocumentationTest extends Documentation {
+
+    private TeamController teamController;
+    private TeamUseCase teamUseCase;
+
+    @BeforeEach
+    void setUp() {
+        teamUseCase = mock(TeamService.class);
+        teamController = new TeamController(teamUseCase);
+        mockMvc = mockController(teamController);
+    }
+
+    @DisplayName("모집글 생성하는 restdocs를 생성한다.")
+    @Test
+    void createProject() {
+        final TeamCreateRequest request = TeamCreateRequestFixture.create("테스트 제목");
+
+        when(teamUseCase.save(any())).thenReturn(TeamFixture.create(
+                        request.subject(),
+                        request.content(),
+                        request.subjectType(),
+                        request.openChatUrl()
+                )
+        );
+
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .post("/team")
+                .then()
+                .status(HttpStatus.CREATED)
+                .apply(resultHandler());
+
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/documentation/step/TeamDocumentStep.java
+++ b/team-service/src/test/java/com/guin/team/documentation/step/TeamDocumentStep.java
@@ -1,0 +1,50 @@
+package com.guin.team.documentation.step;
+
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.RequestFieldsSnippet;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+
+import static com.guin.team.documentation.DocumentPreprocessor.requestPreprocessor;
+import static com.guin.team.documentation.DocumentPreprocessor.responsePreprocessor;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+public class TeamDocumentStep {
+
+    public static RestDocumentationResultHandler resultHandler() {
+        return document(
+                "createProject",
+                requestPreprocessor(),
+                responsePreprocessor(),
+                request(),
+                response()
+        );
+    }
+
+    private static RequestFieldsSnippet request() {
+        return requestFields(
+                fieldWithPath("subject").type(JsonFieldType.STRING).description("모집글 제목"),
+                fieldWithPath("content").type(JsonFieldType.STRING).description("모집글 내용"),
+                fieldWithPath("openChatUrl").type(JsonFieldType.STRING).description("오픈채팅방 URL"),
+                fieldWithPath("subjectType").type(JsonFieldType.STRING).description("프로젝트 종류"),
+                fieldWithPath("teamTemplates").type(JsonFieldType.ARRAY).description("질문 템플렛").optional(),
+                fieldWithPath("types").type(JsonFieldType.ARRAY).description("해시태그").optional(),
+                fieldWithPath("roles").type(JsonFieldType.ARRAY).description("포지션별 참여 인원").optional()
+        );
+    }
+
+    private static ResponseFieldsSnippet response() {
+        return responseFields(
+                fieldWithPath("teamId").type(JsonFieldType.NUMBER).description("모집글 아이디"),
+                fieldWithPath("openChatUrl").type(JsonFieldType.STRING).description("오픈채팅방 URL"),
+                fieldWithPath("content").type(JsonFieldType.STRING).description("모집글 내용"),
+                fieldWithPath("subject").type(JsonFieldType.STRING).description("모집글 제목"),
+                fieldWithPath("subjectType").type(JsonFieldType.STRING).description("프로젝트 종류"),
+                fieldWithPath("teamTemplates").type(JsonFieldType.ARRAY).description("질문 템플렛").optional(),
+                fieldWithPath("types").type(JsonFieldType.ARRAY).description("해시태그").optional(),
+                fieldWithPath("teamRoleDetail").type(JsonFieldType.ARRAY).description("포지션별 참여 인원").optional()
+        );
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/fixture/Fixture.java
+++ b/team-service/src/test/java/com/guin/team/fixture/Fixture.java
@@ -1,0 +1,11 @@
+package com.guin.team.fixture;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+
+public abstract class Fixture {
+    protected static FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .build();
+
+}

--- a/team-service/src/test/java/com/guin/team/fixture/domain/TeamFixture.java
+++ b/team-service/src/test/java/com/guin/team/fixture/domain/TeamFixture.java
@@ -1,0 +1,21 @@
+package com.guin.team.fixture.domain;
+
+import com.guin.team.domain.constant.SubjectType;
+import com.guin.team.domain.vo.Team;
+import com.guin.team.fixture.Fixture;
+
+public class TeamFixture extends Fixture {
+
+    public static Team create(final String subject,
+                              final String content,
+                              final SubjectType subjectType,
+                              final String openChatUrl) {
+        return fixtureMonkey.giveMeBuilder(Team.class)
+                .set("subject", subject)
+                .set("content", content)
+                .set("subjectType", subjectType)
+                .set("openChatUrl", openChatUrl)
+                .sample();
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/fixture/dto/TeamCreateRequestFixture.java
+++ b/team-service/src/test/java/com/guin/team/fixture/dto/TeamCreateRequestFixture.java
@@ -1,0 +1,26 @@
+package com.guin.team.fixture.dto;
+
+import com.guin.team.fixture.Fixture;
+import com.guin.team.adapter.in.web.dto.request.TeamCreateRequest;
+import com.guin.team.domain.constant.SubjectType;
+
+import java.util.Collections;
+import java.util.UUID;
+
+public class TeamCreateRequestFixture extends Fixture {
+
+    public static TeamCreateRequest create(final String subject) {
+        String randomUUID = UUID.randomUUID().toString();
+
+        return new TeamCreateRequest(
+                subject,
+                "content " + randomUUID,
+                randomUUID,
+                SubjectType.PROJECT,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList()
+        );
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/fixture/dto/TeamCreateResponseFixture.java
+++ b/team-service/src/test/java/com/guin/team/fixture/dto/TeamCreateResponseFixture.java
@@ -1,0 +1,27 @@
+package com.guin.team.fixture.dto;
+
+import com.guin.team.adapter.in.web.dto.response.TeamCreateResponse;
+import com.guin.team.domain.constant.SubjectType;
+
+import java.util.Collections;
+
+public class TeamCreateResponseFixture {
+
+    public static TeamCreateResponse create(final Long teamId,
+                                            final String openChatUrl,
+                                            final String content,
+                                            final String subject,
+                                            final SubjectType subjectType) {
+        return new TeamCreateResponse(
+                teamId,
+                openChatUrl,
+                content,
+                subject,
+                subjectType,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList()
+        );
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/integration/ServiceTest.java
+++ b/team-service/src/test/java/com/guin/team/integration/ServiceTest.java
@@ -1,0 +1,18 @@
+package com.guin.team.integration;
+
+import com.guin.team.util.DataCleanUp;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+
+@SpringBootTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+public abstract class ServiceTest {
+
+    @Autowired
+    private DataCleanUp dataCleanUp;
+
+    public void setup() {
+        dataCleanUp.execute();
+    }
+}

--- a/team-service/src/test/java/com/guin/team/integration/fake/FakeTeamUseCaseTest.java
+++ b/team-service/src/test/java/com/guin/team/integration/fake/FakeTeamUseCaseTest.java
@@ -1,0 +1,53 @@
+package com.guin.team.integration.fake;
+
+import com.guin.team.adapter.in.web.dto.request.TeamCreateRequest;
+import com.guin.team.adapter.out.persistence.TeamPersistenceAdapter;
+import com.guin.team.adapter.out.persistence.entity.TeamEntity;
+import com.guin.team.adapter.out.persistence.mapper.TeamMapper;
+import com.guin.team.adapter.out.persistence.repository.TeamRepository;
+import com.guin.team.application.TeamService;
+import com.guin.team.domain.vo.Team;
+import com.guin.team.fixture.dto.TeamCreateRequestFixture;
+import com.guin.team.integration.fake.repository.FakeTeamRepository;
+import com.guin.team.port.in.TeamUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FakeTeamUseCaseTest {
+
+    private final TeamUseCase teamUseCase;
+    private final TeamRepository teamRepository;
+
+    private TeamCreateRequest request;
+
+    public FakeTeamUseCaseTest() {
+        this.teamRepository = new FakeTeamRepository();
+        this.teamUseCase = new TeamService(
+                new TeamPersistenceAdapter(
+                        this.teamRepository,
+                        new TeamMapper()
+                )
+        );
+
+        this.request = TeamCreateRequestFixture.create("제목");
+    }
+
+    @DisplayName("모집글을 생성한다.")
+    @Test
+    void createProject() {
+        Team actual = teamUseCase.save(request);
+        TeamEntity teamEntity = teamRepository.findAll().get(0);
+
+        assertThat(actual).isEqualTo(new Team(
+                teamEntity.getId(),
+                teamEntity.getLeaderId(),
+                teamEntity.getSubject(),
+                teamEntity.getContent(),
+                teamEntity.getSubjectType(),
+                teamEntity.getOpenChatUrl()
+        ));
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/integration/fake/repository/FakeTeamRepository.java
+++ b/team-service/src/test/java/com/guin/team/integration/fake/repository/FakeTeamRepository.java
@@ -1,0 +1,27 @@
+package com.guin.team.integration.fake.repository;
+
+import com.guin.team.adapter.out.persistence.entity.TeamEntity;
+import com.guin.team.adapter.out.persistence.repository.TeamRepository;
+
+import java.util.*;
+
+public class FakeTeamRepository implements TeamRepository {
+
+    private Map<UUID, TeamEntity> teams = new HashMap<>();
+
+    @Override
+    public TeamEntity save(final TeamEntity teamEntity) {
+        teams.put(UUID.randomUUID(), teamEntity);
+        return teamEntity;
+    }
+
+    @Override
+    public Optional<TeamEntity> findById(Long id) {
+        return Optional.ofNullable(teams.get(id));
+    }
+
+    @Override
+    public List<TeamEntity> findAll() {
+        return new ArrayList<>(teams.values());
+    }
+}

--- a/team-service/src/test/java/com/guin/team/integration/inmemory/TeamUseCaseTest.java
+++ b/team-service/src/test/java/com/guin/team/integration/inmemory/TeamUseCaseTest.java
@@ -1,0 +1,65 @@
+package com.guin.team.integration.inmemory;
+
+import com.guin.team.adapter.in.web.dto.request.TeamCreateRequest;
+import com.guin.team.adapter.out.persistence.entity.TeamEntity;
+import com.guin.team.adapter.out.persistence.repository.TeamRepository;
+import com.guin.team.application.TeamService;
+import com.guin.team.domain.vo.Team;
+import com.guin.team.fixture.dto.TeamCreateRequestFixture;
+import com.guin.team.integration.ServiceTest;
+import com.guin.team.port.in.TeamUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TeamUseCaseTest extends ServiceTest {
+
+    private final TeamUseCase teamUseCase;
+    private final TeamRepository teamRepository;
+
+    public TeamUseCaseTest(final TeamService teamService,
+                           final TeamRepository teamRepository) {
+        this.teamUseCase = teamService;
+        this.teamRepository = teamRepository;
+    }
+
+    @BeforeEach
+    void setUp() {
+        super.setup();
+    }
+
+    @DisplayName("모집글을 저장한다.")
+    @Test
+    void save() {
+        TeamCreateRequest request = TeamCreateRequestFixture.create("제목");
+
+        Team team = teamUseCase.save(request);
+
+        TeamEntity teamEntity = teamRepository.findById(team.id())
+                .orElseThrow(RuntimeException::new);
+
+        assertThat(team).isEqualTo(new Team(
+                teamEntity.getId(),
+                teamEntity.getLeaderId(),
+                teamEntity.getSubject(),
+                teamEntity.getContent(),
+                teamEntity.getSubjectType(),
+                teamEntity.getOpenChatUrl()
+        ));
+    }
+
+    @DisplayName("제목이 null이면 에러를 반환한다.")
+    @Test
+    void nullSubjectInvalidException() {
+        TeamCreateRequest request = TeamCreateRequestFixture.create(null);
+
+        assertThatThrownBy(() -> {
+            teamUseCase.save(request);
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+}

--- a/team-service/src/test/java/com/guin/team/util/DataCleanUp.java
+++ b/team-service/src/test/java/com/guin/team/util/DataCleanUp.java
@@ -1,0 +1,46 @@
+package com.guin.team.util;
+
+import com.google.common.base.CaseFormat;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class DataCleanUp implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        tableNames = entityManager.getMetamodel()
+                .getEntities()
+                .stream()
+                .filter(e -> !Objects.isNull(e.getJavaType().getAnnotation(Entity.class)))
+                .map(e -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, e.getJavaType().getAnnotation(Table.class).name()))
+                .collect(Collectors.toList());
+    }
+
+    public void execute() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1").executeUpdate();
+        }
+
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}


### PR DESCRIPTION
## 작업 된 내용

1. 모집글에는 질문이나, 프로젝트 인원같은 선택적인 부분이 너무 커서 다음에 추가 할 예정
2. 헥사고날 아키텍처 적용해보았습니다.
3. 테스트는 인수테스트, 통합테스트를 진행하였습니다.
    - 인수테스트는 restAssured 를 사용하였으며, mock으로는 rest docs를 만들었으며, restAssured는 SpringBootTest를 사용하여 테스트 함.
    - 통합테스트는 일반 인메모리와 페이크 객체를 사용하였습니다.
      -  인메모리는 mock이나 페이크에서 테스트 할 수 없는 nullable 를 테스트 하는데 적합했으며, 페이크함수는 bean을 주입 받는 단계가 없으며, 비교적 빠르게 수행이 가능합니다.


### 아직 구현되지 않은점.

- 회원 정보를 가져오는부분은 아직 완성되지 않아 하드코딩 되어 있습니다.
- 모집글자체가 저장할 내용이 많아, PR올리기 소스가 커져 다음에 추가할 예정
- 모집글은 메인화면에서 많이 사용하며, 최신글 위주로 먼저 보여줄 경우 RDB보다 Nosql DB에 적재해서 사용할 예정

